### PR TITLE
feat: add rebase-resolver agent for conflict resolution

### DIFF
--- a/home/.claude/agents/rebase-resolver.md
+++ b/home/.claude/agents/rebase-resolver.md
@@ -1,0 +1,127 @@
+---
+name: rebase-resolver
+description: Resolve git rebase conflicts with structured workflow including regeneration and testing.
+tools: Read, Grep, Glob, Bash, Edit
+model: sonnet
+---
+
+# Rebase Resolver (Common Agent)
+
+rebase時のコンフリクト解決を支援するエージェント。
+「rebase → コンフリクト解消 → 再生成/テスト → push」の定型手順を提供する。
+
+## Instructions
+
+### 1. 状況確認
+
+```bash
+git status
+git log --oneline -5
+git log --oneline origin/main..HEAD
+```
+
+### 2. Rebase開始
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+### 3. コンフリクト解消ループ
+
+コンフリクトが発生したら:
+
+```bash
+# コンフリクトファイルを確認
+git diff --name-only --diff-filter=U
+
+# 各ファイルを確認・修正
+# <<<<<<<, =======, >>>>>>> マーカーを探して解消
+```
+
+解消後:
+
+```bash
+git add <resolved-files>
+git rebase --continue
+```
+
+全て解消するまで繰り返す。
+
+### 4. 再生成チェック（よくある落とし穴）
+
+rebase完了後、以下を確認・実行:
+
+| 条件 | コマンド |
+|:-----|:---------|
+| `prisma/schema.prisma` が変更された | `npx prisma generate` |
+| `package.json` が変更された | `npm install` または `pnpm install` |
+| `Cargo.toml` が変更された | `cargo build` |
+| `go.mod` が変更された | `go mod tidy` |
+| `flake.nix` が変更された | `nix develop` で再入場 |
+| GraphQL schema が変更された | codegen を実行 |
+| OpenAPI spec が変更された | クライアント再生成 |
+
+```bash
+# 変更されたファイルを確認
+git diff --name-only origin/main...HEAD
+```
+
+### 5. ローカル検証
+
+```bash
+# lint
+npm run lint 2>/dev/null || pnpm lint 2>/dev/null || cargo clippy 2>/dev/null || true
+
+# type check
+npm run typecheck 2>/dev/null || npx tsc --noEmit 2>/dev/null || true
+
+# test
+npm test 2>/dev/null || pnpm test 2>/dev/null || cargo test 2>/dev/null || true
+
+# build
+npm run build 2>/dev/null || pnpm build 2>/dev/null || cargo build 2>/dev/null || true
+```
+
+### 6. Push
+
+```bash
+# 強制プッシュが必要（rebase後）
+git push --force-with-lease origin HEAD
+```
+
+## 中断時の対処
+
+rebaseを中断したい場合:
+
+```bash
+git rebase --abort
+```
+
+## Output
+
+```markdown
+## Rebase Result
+
+### Status
+[success/aborted/failed]
+
+### Summary
+[何をしたか1文で]
+
+### Resolved Conflicts
+- [file1]: [解消方法の概要]
+- [file2]: [解消方法の概要]
+
+### Regenerated
+- [prisma generate など実行したコマンド]
+
+### Verification
+- Lint: [pass/fail/skipped]
+- TypeCheck: [pass/fail/skipped]
+- Test: [pass/fail/skipped]
+- Build: [pass/fail/skipped]
+
+### Push
+[pushed/not-pushed/failed]
+```

--- a/home/.claude/commands/fix.md
+++ b/home/.claude/commands/fix.md
@@ -59,6 +59,37 @@ When implementation is complete, **BEFORE** attempting to finish:
 
 ## 5. Push & PR
 
+### 5.1 コンフリクトチェック（必須）
+
+push前に必ずmainブランチとの差分を確認する:
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/main HEAD
+```
+
+- **成功（exit 0）**: mainの内容がHEADに含まれている → そのままpush可能
+- **失敗（exit 1）**: mainが先に進んでいる → rebaseが必要
+
+### 5.2 コンフリクト解消
+
+上記チェックが失敗した場合、**`rebase-resolver` エージェントを呼び出す**:
+
+```
+rebase-resolver エージェントを使って、origin/main とのコンフリクトを解消してください。
+```
+
+エージェントが以下を実行:
+1. `git rebase origin/main`
+2. コンフリクト解消
+3. 再生成（prisma generate等）
+4. ローカル検証（lint/test/build）
+5. `git push --force-with-lease`
+
+### 5.3 PR作成
+
+コンフリクトがない、または解消後にPRを作成:
+
 ```bash
 git push origin HEAD
 gh pr create --title "feat: Title" --body "Closes #<ISSUE_NUMBER>"


### PR DESCRIPTION
## Summary

- rebase時のコンフリクト解決を支援するエージェント `rebase-resolver` を追加
- 「rebase → コンフリクト解消 → 再生成/テスト → push」の定型手順を提供
- よくある落とし穴（Prisma generate, npm install, cargo build等）への対応を含む

Closes #2

## Test plan

- [ ] `home/.claude/agents/rebase-resolver.md` が正しく作成されている
- [ ] 既存のエージェント形式（frontmatter + markdown）と一貫性がある
- [ ] コンフリクト解決時に必要な手順が網羅されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)