### PR TITLE
feat: レビュー担当をCodexへ移行（ローカルレビュー運用）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ result-*
 *.swp
 *.swo
 *~
+
+# Temporary files (review output, etc.)
+.tmp/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ Nix LSP（nil）とフォーマッタ（nixpkgs-fmt）が使える。
 - AI支援ツールの設定は `home/` に集約
 - プロジェクト固有の設定は各リポジトリで管理
 
+## AIレビュー運用
+
+Claude/Codex/Gemini によるコードレビューは **ローカル実行** を基本とする。
+
+### 使い方
+
+```bash
+# Codex（デフォルト）
+codex "/review <PR_NUMBER>"
+
+# Gemini
+gemini "/review <PR_NUMBER>"
+
+# Claude 経由（サブエージェントにCodexを呼ぶ）
+claude "/review <PR_NUMBER>"
+```
+
+### 出力
+
+- レビュー結果は `.tmp/review_body.md` に保存
+- PR への自動投稿は行わない（CIを無駄に走らせない）
+- 必要なら手動で `gh pr review` を使って投稿
+
 ## 参考
 
 - [Nix](https://nixos.org/)

--- a/home/.claude/commands/review.md
+++ b/home/.claude/commands/review.md
@@ -19,8 +19,17 @@ gh pr view --json number -q .number
 プロジェクト固有のレビューガイダンスがあればそれに従う:
 
 - **`review-guidelines` スキルがある場合**: それを使い、プロジェクトのルールセットに従う
-- **無い場合**: `subagent-review` スキルでGeminiレビューを依頼する
+- **無い場合**: `subagent-review` スキルでレビューを依頼する（**デフォルトは Codex**、Gemini も利用可能）
 
 ## 3. 報告
 
-プロジェクトの慣習に従って、PRにレビューコメントを投稿する。
+レビュー結果は `.tmp/review_body.md` にローカル保存される。
+
+**PR への自動投稿は行わない**。必要に応じてユーザーが手動で投稿する:
+
+```bash
+# 投稿例
+gh pr review <PR_NUMBER> --approve --body-file .tmp/review_body.md
+gh pr review <PR_NUMBER> --request-changes --body-file .tmp/review_body.md
+gh pr review <PR_NUMBER> --comment --body-file .tmp/review_body.md
+```

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -14,6 +14,7 @@
       "Bash(echo *)",
       "Bash(find *)",
       "Bash(git *)",
+      "Bash(codex *)",
       "Bash(gemini *)",
       "Bash(gh *)",
       "Bash(grep *)",

--- a/home/.claude/skills/subagent-review/SKILL.md
+++ b/home/.claude/skills/subagent-review/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: subagent-review
-description: PRのコードレビューをGeminiサブエージェントに依頼する。ユーザーがレビュー依頼/コード確認/「review」と言及したときに使う。
+description: PRのコードレビューをCodexサブエージェントに依頼する。ユーザーがレビュー依頼/コード確認/「review」と言及したときに使う。
 allowed-tools: Bash
 ---
 
-# サブエージェントレビュー（Gemini）
+# サブエージェントレビュー
 
-このスキルは、`gemini` CLI 経由で外部のGeminiエージェントにコードレビューを委譲する。
+このスキルは、外部のAIエージェント（Codex または Gemini）にコードレビューを委譲する。
+**デフォルトは Codex CLI** を使用する。
 
 ## 手順
 
@@ -17,14 +18,26 @@ allowed-tools: Bash
     - ユーザーが番号を指定していればそれを使う
     - 指定がなければ `gh pr view --json number -q .number` で現在のPR番号を取得する
 
-2.  **Geminiを呼び出す**:
+2.  **レビュワーを選択**:
 
-    - `gemini` コマンドでレビュー指示を実行する
-    - 可能なら `--yolo`（安全に使える前提）または対話モードで確実に実行する
-    - **コマンド**:
-      ```bash
-      gemini "/review <PR_NUMBER>" --yolo
-      ```
+    - **デフォルト**: Codex CLI
+    - ユーザーが「Gemini」を指定した場合: Gemini CLI
 
-3.  **報告**:
-    - Geminiにレビュー依頼を送ったことをユーザーに伝える
+3.  **サブエージェントを呼び出す**:
+
+    ### Codex（デフォルト）
+
+    ```bash
+    codex "/review <PR_NUMBER>" --full-auto
+    ```
+
+    ### Gemini（ユーザー指定時）
+
+    ```bash
+    gemini "/review <PR_NUMBER>" --yolo
+    ```
+
+4.  **報告**:
+    - レビュー依頼を送ったことをユーザーに伝える
+    - **結果は `.tmp/review_body.md` に保存される**
+    - PRへの自動投稿は行われない（ユーザーが必要に応じて手動で投稿する）

--- a/home/.codex/skills/review/SKILL.md
+++ b/home/.codex/skills/review/SKILL.md
@@ -1,5 +1,8 @@
-description = "ローカルでコードレビューを実行し、結果をファイルに出力する。PRへの投稿はしない。Usage: /review [PR_NUMBER]"
-prompt = """
+---
+name: review
+description: PRのコードを静的レビューし、結果をローカルファイルに出力する。Usage: /review [PR_NUMBER]
+---
+
 # ローカルコードレビュー
 
 Pull Requestのコードを静的レビューし、結果を **ローカルファイル** に出力する。
@@ -9,12 +12,8 @@ Pull Requestのコードを静的レビューし、結果を **ローカルフ�
 
 ```bash
 # PR番号が引数で渡されている場合はそれを使用
-PR_NUMBER={args}
-
 # なければ現在のブランチのPRを取得
-if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null)
-fi
+PR_NUMBER=${1:-$(gh pr view --json number -q .number 2>/dev/null)}
 
 # PR情報を取得
 gh pr view $PR_NUMBER --json headRefName,baseRefName,title,body
@@ -62,7 +61,7 @@ git diff --name-only origin/<baseRefName>...HEAD
 - `CLAUDE.md`
 - `docs/` ディレクトリ
 - `.cursor/rules/`
-- `.gemini/instructions.md`
+- `.codex/instructions.md`
 
 ## 5. コードをレビュー
 
@@ -89,7 +88,6 @@ git diff --name-only origin/<baseRefName>...HEAD
 
 ```bash
 mkdir -p .tmp
-# ファイル書き込みツールで .tmp/review_body.md に内容を書き出す
 ```
 
 ### 出力フォーマット
@@ -99,7 +97,7 @@ mkdir -p .tmp
 
 **タイトル**: <PR_TITLE>
 **レビュー日**: <DATE>
-**レビュワー**: Gemini CLI
+**レビュワー**: Codex CLI
 
 ## サマリー
 
@@ -148,12 +146,3 @@ mkdir -p .tmp
 - 指摘数のサマリー
 
 **注意**: このレビュー結果を PR に投稿するかどうかはユーザーの判断に委ねる。
-必要であれば以下のコマンドで投稿可能:
-
-```bash
-# 投稿例（ユーザーが手動で実行する場合）
-gh pr review <PR_NUMBER> --approve --body-file .tmp/review_body.md
-gh pr review <PR_NUMBER> --request-changes --body-file .tmp/review_body.md
-gh pr review <PR_NUMBER> --comment --body-file .tmp/review_body.md
-```
-"""


### PR DESCRIPTION
## Summary

- Codex CLI用の`/review`スキルを新規作成
- Gemini/Claudeのレビューフローをローカル出力に統一（PR自動投稿廃止）
- デフォルトのレビュワーをGeminiからCodexに変更
- `.tmp/`をgitignoreに追加し、レビュー出力が誤ってgit管理されないように

## Test plan

- [ ] `codex "/review <PR_NUMBER>"` でローカルレビューが実行できる
- [ ] `gemini "/review <PR_NUMBER>"` でローカルレビューが実行できる
- [ ] `.tmp/review_body.md` が生成され、内容が日本語
- [ ] PRには何も自動投稿されない
- [ ] `git status`に`.tmp/`が出てこない（ignoreされている）

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)